### PR TITLE
Add hover state for collapsed row component of fat row.

### DIFF
--- a/src/components/entityList/entity-list.less
+++ b/src/components/entityList/entity-list.less
@@ -38,6 +38,10 @@
               color: @color-tungsten;
             }
           }
+          &-collapsed-row:hover {
+            cursor: pointer;
+            background-color: @color-fog;
+          }
         }
         .row-name {
           color: @color-asphalt;


### PR DESCRIPTION
Usage:

```
<div class="wrapper wrapper-collapsed-row">
    <div class="element">
        <span>field 1</span>
    </div>
    <div class="element">
        <span>field 2</span>
    </div>
    <div class="element">
        <span>field 3</span>
    </div>
</div>
```

<img width="1280" alt="screen shot 2016-09-30 at 2 15 09 pm" src="https://cloud.githubusercontent.com/assets/12063122/19007355/8255d2e0-8719-11e6-9d06-2bc9ef3fa820.png">
