### PR TITLE
Add contrast to hover state for row action icons and handle disabled state.

### DIFF
--- a/src/components/entityList/entity-list.less
+++ b/src/components/entityList/entity-list.less
@@ -33,9 +33,14 @@
           .row-actions {
             .fa {
               margin-right: 6px;
+              color: @color-cobalt;
             }
-            .fa:hover {
-              color: @color-tungsten;
+            .fa.disabled {
+              color: @color-aluminium;
+            }
+            .fa:not(.disabled):hover {
+              color: @color-asphalt;
+              cursor: pointer;
             }
           }
           &-collapsed-row:hover {


### PR DESCRIPTION
<img width="1280" alt="screen shot 2016-10-03 at 7 54 29 am" src="https://cloud.githubusercontent.com/assets/12063122/19041903/db0e1312-893e-11e6-9134-4842808895eb.png">
^ Left icon: enabled, right icon: disabled

<img width="1280" alt="screen shot 2016-10-03 at 7 48 23 am" src="https://cloud.githubusercontent.com/assets/12063122/19041922/e91ed75c-893e-11e6-9e9a-090501866f86.png">
^ Left icon: enabled + hover, right icon: disabled

<img width="1280" alt="screen shot 2016-10-03 at 7 49 24 am" src="https://cloud.githubusercontent.com/assets/12063122/19041935/f684f2d2-893e-11e6-9a56-a155e69b7e51.png">
^ Left icon: enabled, right icon: disabled + hover
