### PR TITLE
Adjust overflow style

### DIFF
--- a/src/globals/apigee-template.less
+++ b/src/globals/apigee-template.less
@@ -34,7 +34,6 @@ code, pre {
   position: relative;
   min-width: @min-width;
   width: 100%;
-  overflow-y: hidden;
 
   .tooltip-fake {
     position: absolute;


### PR DESCRIPTION
Filtering dropdown is clipped on short lists (see attached pics) in apigee-stilo 0.1.9. (see pics)

List pages seem to be fixed by removing this style, which is handled for list pages by the ng2-ue-utils component 'HintScroll'.  

Tested fix locally on top of Org-History and Apps SPAs with apigee-stilo 0.1.9.  

@coverbeck @stevejs Is this style used/needed by shoehorned UI, portals or spechub?

Before:
<img width="1011" alt="screen shot 2016-10-17 at 10 49 14 am" src="https://cloud.githubusercontent.com/assets/12063122/19449536/d37f4482-945a-11e6-9d17-9a585577a32d.png">

After:
<img width="1017" alt="screen shot 2016-10-17 at 10 49 02 am" src="https://cloud.githubusercontent.com/assets/12063122/19449532/cce69d78-945a-11e6-9aa5-8f8c09ec0410.png">
