### PR TITLE
Adjust style to account for change in ng2-ue-utils introduced in 3.3.0.

### DIFF
--- a/src/components/patterns/entity-list.less
+++ b/src/components/patterns/entity-list.less
@@ -5,7 +5,7 @@
     display: block;
     // modal
     .modal-bold {
-      font-weight: 500;
+      font-weight: 700;
       color: @color-asphalt
     }
     // content


### PR DESCRIPTION
Before:
<img width="600" alt="screen shot 2017-03-29 at 1 05 35 pm" src="https://cloud.githubusercontent.com/assets/12063122/24474165/92b2cab8-1480-11e7-8b22-533f4e3e1cbd.png">

After:
<img width="693" alt="screen shot 2017-03-29 at 1 06 26 pm" src="https://cloud.githubusercontent.com/assets/12063122/24474173/98caa100-1480-11e7-9250-e04fc0878ac5.png">

@wigahluk A change to the Modal component in version 3.3.0 of ng2-ue-utils removed some locally-applied styles from its Modal component.  This change made its text darker, which was good considering our contrast issues.  However it also became difficult to tell the difference between regular and bold text (see "before" ^), which this MR fixes.

No need to publish a new version of the library just yet.  I will add the style directly to each of the SPAs, along with a TODO to remove the style once the app is using apigee stilo > 0.2.5 (0.2.5 is current).